### PR TITLE
[performance] Improve the performance of FastCounter

### DIFF
--- a/bench/fast_counter/increment.exs
+++ b/bench/fast_counter/increment.exs
@@ -1,0 +1,19 @@
+Application.ensure_all_started(:instruments)
+
+Benchee.run(
+  %{
+    "increment" => fn options ->
+      for _ <- 1..100 do
+        Instruments.FastCounter.increment("test.counter", 1, options)
+      end
+    end
+  },
+  inputs: %{
+    "1. No Options" => [],
+    "2. No Tags" => [sample_rate: 1.0],
+    "3. Empty Tags" => [sample_rate: 1.0, tags: []],
+    "4. One Tag" => [sample_rate: 1.0, tags: ["test:tag"]],
+    "5. Five Tags" => [sample_rate: 1.0, tags: ["test-1:tag", "test-2:tag", "test-3:tag", "test-4:tag", "test-5:tag"]],
+    "6. Ten Tags" => [sample_rate: 1.0, tags: ["test-1:tag", "test-2:tag", "test-3:tag", "test-4:tag", "test-5:tag", "test-6:tag", "test-7:tag", "test-8:tag", "test-9:tag", "test-10:tag"]]
+  }
+)

--- a/bench/fast_counter/tag_handling.exs
+++ b/bench/fast_counter/tag_handling.exs
@@ -1,0 +1,109 @@
+keyword_merge = fn input ->
+  for _ <- 1..100 do
+    case Keyword.get(input, :tags) do
+      tags when is_list(tags) ->
+        {:test, Keyword.merge(input, tags: Enum.sort(tags))}
+
+      _ ->
+        {:test, input}
+    end
+  end
+end
+
+keyword_merge_special = fn input ->
+  for _ <- 1..100 do
+    case Keyword.get(input, :tags) do
+      [] ->
+        {:test, input}
+
+      [_] ->
+        {:test, input}
+
+      tags when is_list(tags) ->
+        {:test, Keyword.merge(input, tags: Enum.sort(tags))}
+
+      _ ->
+        {:test, input}
+    end
+  end
+end
+
+keyword_pop_and_put = fn input ->
+  for _ <- 1..100 do
+    case Keyword.pop(input, :tags) do
+      {tags, input} when is_list(tags) ->
+        {:test, Keyword.put(input, :tags, Enum.sort(tags))}
+
+      _ ->
+        {:test, input}
+    end
+  end
+end
+
+keyword_pop_and_put_special = fn input ->
+  for _ <- 1..100 do
+    case Keyword.pop(input, :tags) do
+      {[], _} ->
+        {:test, input}
+
+      {[_], _} ->
+        {:test, input}
+
+      {tags, input} when is_list(tags) ->
+        {:test, Keyword.put(input, :tags, Enum.sort(tags))}
+
+      _ ->
+        {:test, input}
+    end
+  end
+end
+
+keyword_replace = fn input ->
+  for _ <- 1..100 do
+    case Keyword.get(input, :tags) do
+      tags when is_list(tags) ->
+        {:test, Keyword.replace!(input, :tags, Enum.sort(tags))}
+
+      _ ->
+        {:test, input}
+    end
+  end
+end
+
+keyword_replace_special = fn input ->
+  for _ <- 1..100 do
+    case Keyword.get(input, :tags) do
+      [] ->
+        {:test, input}
+
+      [_] ->
+        {:test, input}
+
+      tags when is_list(tags) ->
+        {:test, Keyword.replace!(input, :tags, Enum.sort(tags))}
+
+      _ ->
+        {:test, input}
+    end
+  end
+end
+
+
+Benchee.run(
+  %{
+    "Keyword.get/2 + Keyword.merge/2" => &keyword_merge.(&1),
+    "Keyword.pop/2 + Keyword.put/3" => &keyword_pop_and_put.(&1),
+    "Keyword.get/2 + Keyword.replace!/3" => &keyword_replace.(&1),
+    "Keyword.get/2 + Keyword.merge/2 with Special Casing" => &keyword_merge_special.(&1),
+    "Keyword.pop/2 + Keyword.put/3 with Special Casing" => &keyword_pop_and_put_special.(&1),
+    "Keyword.get/2 + Keyword.replace!/3 with Special Casing" => &keyword_replace_special.(&1),
+  },
+  inputs: %{
+    "1. No Options" => [],
+    "2. No Tags" => [sample_rate: 1.0],
+    "3. Empty Tags" => [sample_rate: 1.0, tags: []],
+    "4. One Tag" => [sample_rate: 1.0, tags: ["test:tag"]],
+    "5. Five Tags" => [sample_rate: 1.0, tags: ["test-1:tag", "test-2:tag", "test-3:tag", "test-4:tag", "test-5:tag"]],
+    "6. Ten Tags" => [sample_rate: 1.0, tags: ["test-1:tag", "test-2:tag", "test-3:tag", "test-4:tag", "test-5:tag", "test-6:tag", "test-7:tag", "test-8:tag", "test-9:tag", "test-10:tag"]]
+  }
+)

--- a/bench/results/fast_counter/increment/strategy-1.txt
+++ b/bench/results/fast_counter/increment/strategy-1.txt
@@ -1,0 +1,52 @@
+v1 Fast Counter Strategy
+
+Original release Fast Counter Strategy.  Creates a semi-stable key by sorting tags and merging them back into the
+options.
+
+Output of Benchmark
+
+Operating System: macOS
+CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+Number of Available Cores: 16
+Available memory: 64 GB
+Elixir 1.7.4
+Erlang 21.3.8.10
+
+Benchmark suite executing with the following configuration:
+warmup: 2 s
+time: 5 s
+memory time: 0 ns
+parallel: 1
+inputs: 1. No Options, 2. No Tags, 3. Empty Tags, 4. One Tag, 5. Five Tags, 6. Ten Tags
+Estimated total run time: 42 s
+
+Benchmarking increment with input 1. No Options...
+Benchmarking increment with input 2. No Tags...
+Benchmarking increment with input 3. Empty Tags...
+Benchmarking increment with input 4. One Tag...
+Benchmarking increment with input 5. Five Tags...
+Benchmarking increment with input 6. Ten Tags...
+
+##### With input 1. No Options #####
+Name                ips        average  deviation         median         99th %
+increment       41.87 K       23.89 μs    ±40.66%          22 μs          70 μs
+
+##### With input 2. No Tags #####
+Name                ips        average  deviation         median         99th %
+increment       34.17 K       29.26 μs    ±42.41%          25 μs          87 μs
+
+##### With input 3. Empty Tags #####
+Name                ips        average  deviation         median         99th %
+increment       19.19 K       52.12 μs    ±38.40%          45 μs         140 μs
+
+##### With input 4. One Tag #####
+Name                ips        average  deviation         median         99th %
+increment       17.84 K       56.05 μs    ±38.08%       48.00 μs         150 μs
+
+##### With input 5. Five Tags #####
+Name                ips        average  deviation         median         99th %
+increment       11.15 K       89.72 μs    ±34.33%       78.00 μs      223.00 μs
+
+##### With input 6. Ten Tags #####
+Name                ips        average  deviation         median         99th %
+increment        6.58 K      151.97 μs    ±30.37%         134 μs         353 μs

--- a/bench/results/fast_counter/increment/strategy-2.txt
+++ b/bench/results/fast_counter/increment/strategy-2.txt
@@ -65,7 +65,6 @@ Compared to v1 Average: -21.08 μs ✅
 Compared to v1 Median : -16.02 μs ✅
 Compared to v1 99th % : -53.02 μs ✅
 
-
 ##### With input 5. Five Tags #####
 Name                ips        average  deviation         median         99th %
 increment       12.06 K       82.89 μs    ±35.25%       71.98 μs      204.98 μs

--- a/bench/results/fast_counter/increment/strategy-2.txt
+++ b/bench/results/fast_counter/increment/strategy-2.txt
@@ -1,0 +1,85 @@
+v2 Fast Counter Strategy
+
+Minor Changes to how `increment/3` works
+
+- Add a special case function for when no options are passed that avoids the more complex table key logic
+- Use the faster tag handling strategy, see the tag_handling/analysis.txt
+
+Output of Benchmark
+
+Operating System: macOS
+CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+Number of Available Cores: 16
+Available memory: 64 GB
+Elixir 1.7.4
+Erlang 21.3.8.10
+
+Benchmark suite executing with the following configuration:
+warmup: 2 s
+time: 5 s
+memory time: 0 ns
+parallel: 1
+inputs: 1. No Options, 2. No Tags, 3. Empty Tags, 4. One Tag, 5. Five Tags, 6. Ten Tags
+Estimated total run time: 42 s
+
+Benchmarking increment with input 1. No Options...
+Benchmarking increment with input 2. No Tags...
+Benchmarking increment with input 3. Empty Tags...
+Benchmarking increment with input 4. One Tag...
+Benchmarking increment with input 5. Five Tags...
+Benchmarking increment with input 6. Ten Tags...
+
+##### With input 1. No Options #####
+Name                ips        average  deviation         median         99th %
+increment       46.50 K       21.51 μs    ±40.73%       18.98 μs       62.98 μs
+
+Compared to v1 IPS    : +4.63K    ✅
+Compared to v1 Average: -2.38 μs  ✅
+Compared to v1 Median : -3.02 μs  ✅
+Compared to v1 99th % : -7.02 μs  ✅
+
+##### With input 2. No Tags #####
+Name                ips        average  deviation         median         99th %
+increment       34.87 K       28.68 μs    ±36.49%       25.98 μs       79.98 μs
+
+Compared to v1 IPS    : +0.70K    ✅
+Compared to v1 Average: -0.58 μs  ✅
+Compared to v1 Median : +0.90 μs  ❌
+Compared to v1 99th % : -7.02 μs  ✅
+
+##### With input 3. Empty Tags #####
+Name                ips        average  deviation         median         99th %
+increment       30.62 K       32.66 μs    ±38.21%       28.98 μs       91.98 μs
+
+Compared to v1 IPS    : +11.43K   ✅
+Compared to v1 Average: -19.46 μs ✅
+Compared to v1 Median : -16.02 μs ✅
+Compared to v1 99th % : -48.02 μs ✅
+
+##### With input 4. One Tag #####
+Name                ips        average  deviation         median         99th %
+increment       28.60 K       34.97 μs    ±36.25%       31.98 μs       96.98 μs
+
+Compared to v1 IPS    : +10.76K   ✅
+Compared to v1 Average: -21.08 μs ✅
+Compared to v1 Median : -16.02 μs ✅
+Compared to v1 99th % : -53.02 μs ✅
+
+
+##### With input 5. Five Tags #####
+Name                ips        average  deviation         median         99th %
+increment       12.06 K       82.89 μs    ±35.25%       71.98 μs      204.98 μs
+
+Compared to v1 IPS    : +0.91K    ✅
+Compared to v1 Average: -6.83 μs  ✅
+Compared to v1 Median : -6.02 μs  ✅
+Compared to v1 99th % : -18.02 μs ✅
+
+##### With input 6. Ten Tags #####
+Name                ips        average  deviation         median         99th %
+increment        7.41 K      135.02 μs    ±30.81%      118.98 μs      319.98 μs
+
+Compared to v1 IPS    : +0.83K    ✅
+Compared to v1 Average: -16.95 μs ✅
+Compared to v1 Median : -15.02 μs ✅
+Compared to v1 99th % : -33.02 μs ✅

--- a/bench/results/fast_counter/increment/strategy-3.txt
+++ b/bench/results/fast_counter/increment/strategy-3.txt
@@ -1,0 +1,81 @@
+v3 Fast Counter Strategy
+
+Same strategy as v2 but code was changed to extract the table_key building into an inline function
+
+Output of Benchmark
+
+Operating System: macOS
+CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+Number of Available Cores: 16
+Available memory: 64 GB
+Elixir 1.7.4
+Erlang 21.3.8.10
+
+Benchmark suite executing with the following configuration:
+warmup: 2 s
+time: 5 s
+memory time: 0 ns
+parallel: 1
+inputs: 1. No Options, 2. No Tags, 3. Empty Tags, 4. One Tag, 5. Five Tags, 6. Ten Tags
+Estimated total run time: 42 s
+
+Benchmarking increment with input 1. No Options...
+Benchmarking increment with input 2. No Tags...
+Benchmarking increment with input 3. Empty Tags...
+Benchmarking increment with input 4. One Tag...
+Benchmarking increment with input 5. Five Tags...
+Benchmarking increment with input 6. Ten Tags...
+
+##### With input 1. No Options #####
+Name                ips        average  deviation         median         99th %
+increment       47.05 K       21.25 μs    ±37.14%       19.98 μs       60.98 μs
+
+Compared to v2 IPS    : +0.55K    ✅
+Compared to v2 Average: -0.26 μs  ❌
+Compared to v2 Median : +1.00 μs  ✅
+Compared to v2 99th % : -2.00 μs  ✅
+
+##### With input 2. No Tags #####
+Name                ips        average  deviation         median         99th %
+increment       36.19 K       27.63 μs    ±31.73%       25.98 μs       74.98 μs
+
+Compared to v2 IPS    : +1.23K    ✅
+Compared to v2 Average: -1.05 μs  ✅
+Compared to v2 Median : +/- 0 μs  ✅
+Compared to v2 99th % : -5.00 μs  ✅
+
+##### With input 3. Empty Tags #####
+Name                ips        average  deviation         median         99th %
+increment       32.72 K       30.57 μs    ±29.42%       28.98 μs       78.98 μs
+
+Compared to v2 IPS    : +2.10K    ✅
+Compared to v2 Average: -2.09 μs  ✅
+Compared to v2 Median : +/- 0 μs  ✅
+Compared to v2 99th % : -13.00 μs ✅
+
+##### With input 4. One Tag #####
+Name                ips        average  deviation         median         99th %
+increment       29.47 K       33.93 μs    ±31.08%       30.98 μs       87.98 μs
+
+Compared to v2 IPS    : +0.87K    ✅
+Compared to v2 Average: -1.04 μs  ✅
+Compared to v2 Median : -1.00 μs  ✅
+Compared to v2 99th % : -9.00 μs  ✅
+
+##### With input 5. Five Tags #####
+Name                ips        average  deviation         median         99th %
+increment       13.81 K       72.42 μs    ±22.17%       68.98 μs      157.98 μs
+
+Compared to v2 IPS    : +1.75K    ✅
+Compared to v2 Average: -10.47 μs ✅
+Compared to v2 Median : -3.00 μs  ✅
+Compared to v2 99th % : -47.00 μs ✅
+
+##### With input 6. Ten Tags #####
+Name                ips        average  deviation         median         99th %
+increment        7.68 K      130.14 μs    ±25.45%      118.98 μs      287.98 μs
+
+Compared to v2 IPS    : +0.27K    ✅
+Compared to v2 Average: -4.88 μs  ✅
+Compared to v2 Median : +/- 0 μs  ✅
+Compared to v2 99th % : -32.00 μs ✅

--- a/bench/results/fast_counter/tag_handling/analysis.txt
+++ b/bench/results/fast_counter/tag_handling/analysis.txt
@@ -1,0 +1,106 @@
+Values presented are thousands of iterations per second, higher is better.
+
+For each scenario scores are calculated, scores are calculate with the following formula.
+
+score = round(((total - worst) / (best - worst)) * 100)
+
+##### With input 1. No Options #####
+                                                       | Run 1 | Run 2 | Run 3 | Average | Total | Score |
+                                                       |-------|-------|-------|---------|-------|-------|
+Keyword.get/2 + Keyword.merge/2                        |  177  |  177  |  166  |   173   |  520  |  100  |
+Keyword.get/2 + Keyword.replace!/3                     |  158  |  166  |  160  |   161   |  484  |   73  |
+Keyword.get/2 + Keyword.merge/2 with Special Casing    |  155  |  167  |  158  |   160   |  480  |   70  |
+Keyword.get/2 + Keyword.replace!/3 with Special Casing |  150  |  160  |  161  |   157   |  471  |   64  |
+Keyword.pop/2 + Keyword.put/3 with Special Casing      |  127  |  129  |  130  |   129   |  386  |    1  |
+Keyword.pop/2 + Keyword.put/3                          |  119  |  135  |  131  |   128   |  385  |    0  |
+
+##### With input 2. No Tags #####
+
+                                                       | Run 1 | Run 2 | Run 3 | Average | Total | Score |
+                                                       |-------|-------|-------|---------|-------|-------|
+Keyword.get/2 + Keyword.merge/2                        |  175  |  174  |  156  |   168   |  505  |  100  |
+Keyword.get/2 + Keyword.replace!/3                     |  151  |  166  |  153  |   156   |  470  |   72  |
+Keyword.get/2 + Keyword.merge/2 with Special Casing    |  154  |  139  |  154  |   149   |  447  |   54  |
+Keyword.get/2 + Keyword.replace!/3 with Special Casing |  145  |  135  |  157  |   146   |  437  |   46  |
+Keyword.pop/2 + Keyword.put/3 with Special Casing      |  125  |  128  |  128  |   127   |  381  |    1  |
+Keyword.pop/2 + Keyword.put/3                          |  119  |  132  |  129  |   127   |  380  |    0  |
+
+##### With input 3. Empty Tags #####
+
+                                                       | Run 1 | Run 2 | Run 3 | Average | Total | Score |
+                                                       |-------|-------|-------|---------|-------|-------|
+Keyword.get/2 + Keyword.merge/2 with Special Casing    |  147  |  150  |  150  |   149   |  447  |  100  |
+Keyword.get/2 + Keyword.replace!/3 with Special Casing |  136  |  147  |  153  |   145   |  436  |   97  |
+Keyword.pop/2 + Keyword.put/3 with Special Casing      |   73  |   71  |   77  |    74   |  221  |   30  |
+Keyword.get/2 + Keyword.replace!/3                     |   58  |   65  |   62  |    62   |  185  |   18  |
+Keyword.pop/2 + Keyword.put/3                          |   50  |   61  |   54  |    55   |  165  |   12  |
+Keyword.get/2 + Keyword.merge/2                        |   44  |   42  |   40  |    42   |  126  |    0  |
+
+
+
+##### With input 4. One Tag #####
+
+                                                       | Run 1 | Run 2 | Run 3 | Average | Total | Score |
+                                                       |-------|-------|-------|---------|-------|-------|
+Keyword.get/2 + Keyword.replace!/3 with Special Casing |  144  |  152  |  153  |   150   |  449  |  100  |
+Keyword.get/2 + Keyword.merge/2 with Special Casing    |  143  |  154  |  150  |   149   |  447  |   99  |
+Keyword.pop/2 + Keyword.put/3 with Special Casing      |   73  |   74  |   75  |    74   |  222  |   30  |
+Keyword.get/2 + Keyword.replace!/3                     |   58  |   65  |   59  |    61   |  182  |   17  |
+Keyword.pop/2 + Keyword.put/3                          |   50  |   57  |   51  |    53   |  158  |   10  |
+Keyword.get/2 + Keyword.merge/2                        |   43  |   42  |   41  |    42   |  126  |    0  |
+
+##### With input 5. Five Tags #####
+
+                                                       | Run 1 | Run 2 | Run 3 | Average | Total | Score |
+                                                       |-------|-------|-------|---------|-------|-------|
+Keyword.get/2 + Keyword.replace!/3 with Special Casing |   26  |   30  |   29  |    28   |   85  |  100  |
+Keyword.get/2 + Keyword.replace!/3                     |   27  |   29  |   28  |    28   |   84  |   95  |
+Keyword.pop/2 + Keyword.put/3 with Special Casing      |   26  |   27  |   27  |    27   |   80  |   76  |
+Keyword.pop/2 + Keyword.put/3                          |   23  |   27  |   26  |    25   |   76  |   57  |
+Keyword.get/2 + Keyword.merge/2                        |   24  |   23  |   22  |    23   |   69  |   24  |
+Keyword.get/2 + Keyword.merge/2 with Special Casing    |   21  |   22  |   21  |    21   |   64  |    0  |
+
+##### With input 6. Ten Tags #####
+
+                                                       | Run 1 | Run 2 | Run 3 | Average | Total | Score |
+                                                       |-------|-------|-------|---------|-------|-------|
+Keyword.pop/2 + Keyword.put/3 with Special Casing      |   13  |   13  |   13  |    13   |   39  |  100  |
+Keyword.get/2 + Keyword.replace!/3 with Special Casing |   11  |   13  |   13  |    12   |   37  |   71  |
+Keyword.get/2 + Keyword.replace!/3                     |   11  |   12  |   13  |    12   |   36  |   57  |
+Keyword.get/2 + Keyword.merge/2                        |   12  |   11  |   11  |    11   |   34  |   29  |
+Keyword.pop/2 + Keyword.put/3                          |   11  |   12  |   11  |    11   |   34  |   29  |
+Keyword.get/2 + Keyword.merge/2 with Special Casing    |   11  |   11  |   10  |    11   |   32  |    0  |
+
+#### Overall Score Analysis ####
+
+                                                       | Case 1 | Case 2 | Case 3 | Case 4 | Case 5 | Case 6 | Total | Average |
+                                                       |--------|--------|--------|--------|--------|--------|-------|---------|
+Keyword.get/2 + Keyword.replace!/3 with Special Casing |    64  |    46  |    97  |   100  |   100  |    71  |  478  |    80   |
+Keyword.get/2 + Keyword.replace!/3                     |    73  |    72  |    18  |    17  |    95  |    57  |  332  |    55   |
+Keyword.get/2 + Keyword.merge/2 with Special Casing    |    70  |    54  |   100  |    99  |     0  |     0  |  323  |    54   |
+Keyword.get/2 + Keyword.merge/2                        |   100  |   100  |     0  |     0  |    24  |    29  |  253  |    42   |
+Keyword.pop/2 + Keyword.put/3 with Special Casing      |     1  |     1  |    30  |    30  |    76  |   100  |  238  |    39   |
+Keyword.pop/2 + Keyword.put/3                          |     0  |     0  |    12  |    10  |    57  |    29  |  108  |    18   |
+
+
+#### Results ####
+
+Keyword.get/2 + Keyword.replace!/3 with Special Casing on average is the best performing algorithm for tag handling
+
+Performance Report compared to best
+
+       |  Run 1   |  Run 2  |  Run 3  | Average |
+       |----------|---------|---------|---------|
+Case 1 |  +0.90μs | +0.59μs | +0.19μs | +0.56μs |
+Case 2 |  +1.22μs | +1.63μs | -0.01μs | +0.95μs |
+Case 3 |  +0.55μs | +0.17μs | -0.14μs | +0.19μs |
+Case 4 |  -0.04μs | +0.07μs | -0.11μs | -0.08μs |
+Case 5 |  -1.20μs | -1.49μs | -1.43μs | -1.37μs |
+Case 6 | +10.04μs | -0.41μs | +1.43μs | +3.69μs |
+
+Worst underperformance is the outlier Run 1 / Case 6 where this strategy underperformed by 10.04μs.
+
+Overall the strategy is never worse than +10.04μs than the best strategy and outperforms all other strategies by up to -1.49μs in some scenarios.
+
+With the outlier removed, the performance envelope for this strategy is within a tolerance of +1.63μs from being the best strategy in all cases.
+

--- a/bench/results/fast_counter/tag_handling/run-1.txt
+++ b/bench/results/fast_counter/tag_handling/run-1.txt
@@ -1,0 +1,153 @@
+Operating System: macOS
+CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+Number of Available Cores: 16
+Available memory: 64 GB
+Elixir 1.7.4
+Erlang 21.3.8.10
+
+Benchmark suite executing with the following configuration:
+warmup: 2 s
+time: 5 s
+memory time: 0 ns
+parallel: 1
+inputs: 1. No Options, 2. No Tags, 3. Empty Tags, 4. One Tag, 5. Five Tags, 6. Ten Tags
+Estimated total run time: 4.20 min
+
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 1. No Options...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 2. No Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 3. Empty Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 4. One Tag...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 5. Five Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 6. Ten Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 1. No Options...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 2. No Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 3. Empty Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 4. One Tag...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 5. Five Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 6. Ten Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 1. No Options...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 2. No Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 3. Empty Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 4. One Tag...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 5. Five Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 6. Ten Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 1. No Options...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 2. No Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 3. Empty Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 4. One Tag...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 5. Five Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 6. Ten Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 1. No Options...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 2. No Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 3. Empty Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 4. One Tag...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 5. Five Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 6. Ten Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 1. No Options...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 2. No Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 3. Empty Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 4. One Tag...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 5. Five Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 6. Ten Tags...
+
+##### With input 1. No Options #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.merge/2                             173.58 K        5.76 μs   ±217.77%           5 μs          26 μs
+Keyword.get/2 + Keyword.replace!/3                          158.46 K        6.31 μs   ±144.04%           6 μs          27 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         155.24 K        6.44 μs   ±126.07%           6 μs          29 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      150.05 K        6.66 μs   ±134.41%           6 μs          28 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing           127.09 K        7.87 μs   ±115.74%           7 μs          30 μs
+Keyword.pop/2 + Keyword.put/3                               119.39 K        8.38 μs   ±121.42%           8 μs          30 μs
+
+Comparison:
+Keyword.get/2 + Keyword.merge/2                             173.58 K
+Keyword.get/2 + Keyword.replace!/3                          158.46 K - 1.10x slower +0.55 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         155.24 K - 1.12x slower +0.68 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      150.05 K - 1.16x slower +0.90 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing           127.09 K - 1.37x slower +2.11 μs
+Keyword.pop/2 + Keyword.put/3                               119.39 K - 1.45x slower +2.61 μs
+
+##### With input 2. No Tags #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.merge/2                             175.59 K        5.70 μs   ±235.28%           5 μs          26 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         154.30 K        6.48 μs   ±138.74%           6 μs          29 μs
+Keyword.get/2 + Keyword.replace!/3                          151.31 K        6.61 μs   ±136.86%           6 μs          28 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      144.60 K        6.92 μs   ±164.46%           7 μs          17 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing           125.17 K        7.99 μs   ±130.25%           7 μs          31 μs
+Keyword.pop/2 + Keyword.put/3                               119.29 K        8.38 μs   ±124.92%           7 μs          34 μs
+
+Comparison:
+Keyword.get/2 + Keyword.merge/2                             175.59 K
+Keyword.get/2 + Keyword.merge/2 with Special Casing         154.30 K - 1.14x slower +0.79 μs
+Keyword.get/2 + Keyword.replace!/3                          151.31 K - 1.16x slower +0.91 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      144.60 K - 1.21x slower +1.22 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing           125.17 K - 1.40x slower +2.29 μs
+Keyword.pop/2 + Keyword.put/3                               119.29 K - 1.47x slower +2.69 μs
+
+##### With input 3. Empty Tags #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.merge/2 with Special Casing         147.21 K        6.79 μs   ±143.28%           6 μs          30 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      136.14 K        7.35 μs   ±121.45%           7 μs          21 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            72.95 K       13.71 μs    ±48.37%          12 μs          44 μs
+Keyword.get/2 + Keyword.replace!/3                           58.27 K       17.16 μs    ±39.63%          16 μs          38 μs
+Keyword.pop/2 + Keyword.put/3                                50.46 K       19.82 μs    ±51.60%          17 μs          62 μs
+Keyword.get/2 + Keyword.merge/2                              43.69 K       22.89 μs    ±41.07%          21 μs          65 μs
+
+Comparison:
+Keyword.get/2 + Keyword.merge/2 with Special Casing         147.21 K
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      136.14 K - 1.08x slower +0.55 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            72.95 K - 2.02x slower +6.92 μs
+Keyword.get/2 + Keyword.replace!/3                           58.27 K - 2.53x slower +10.37 μs
+Keyword.pop/2 + Keyword.put/3                                50.46 K - 2.92x slower +13.02 μs
+Keyword.get/2 + Keyword.merge/2                              43.69 K - 3.37x slower +16.09 μs
+
+##### With input 4. One Tag #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      143.50 K        6.97 μs   ±129.37%           6 μs          30 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         142.58 K        7.01 μs   ±129.65%           6 μs          29 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            72.57 K       13.78 μs    ±50.94%          12 μs          46 μs
+Keyword.get/2 + Keyword.replace!/3                           58.44 K       17.11 μs    ±43.30%          16 μs          37 μs
+Keyword.pop/2 + Keyword.put/3                                49.73 K       20.11 μs    ±49.34%          17 μs          62 μs
+Keyword.get/2 + Keyword.merge/2                              43.23 K       23.13 μs    ±41.80%          21 μs          65 μs
+
+Comparison:
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      143.50 K
+Keyword.get/2 + Keyword.merge/2 with Special Casing         142.58 K - 1.01x slower +0.0446 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            72.57 K - 1.98x slower +6.81 μs
+Keyword.get/2 + Keyword.replace!/3                           58.44 K - 2.46x slower +10.14 μs
+Keyword.pop/2 + Keyword.put/3                                49.73 K - 2.89x slower +13.14 μs
+Keyword.get/2 + Keyword.merge/2                              43.23 K - 3.32x slower +16.16 μs
+
+##### With input 5. Five Tags #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.replace!/3                           27.19 K       36.78 μs    ±39.29%          32 μs         101 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            26.33 K       37.98 μs    ±37.51%          34 μs         105 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing       25.99 K       38.48 μs    ±34.21%          36 μs          98 μs
+Keyword.get/2 + Keyword.merge/2                              23.85 K       41.93 μs    ±30.92%          38 μs         105 μs
+Keyword.pop/2 + Keyword.put/3                                23.15 K       43.19 μs    ±26.28%          40 μs          92 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing          21.33 K       46.88 μs    ±36.12%          42 μs         121 μs
+
+Comparison:
+Keyword.get/2 + Keyword.replace!/3                           27.19 K
+Keyword.pop/2 + Keyword.put/3 with Special Casing            26.33 K - 1.03x slower +1.20 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing       25.99 K - 1.05x slower +1.70 μs
+Keyword.get/2 + Keyword.merge/2                              23.85 K - 1.14x slower +5.15 μs
+Keyword.pop/2 + Keyword.put/3                                23.15 K - 1.17x slower +6.41 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing          21.33 K - 1.27x slower +10.10 μs
+
+##### With input 6. Ten Tags #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.pop/2 + Keyword.put/3 with Special Casing            12.84 K       77.90 μs    ±28.77%          71 μs         185 μs
+Keyword.get/2 + Keyword.merge/2                              11.58 K       86.37 μs    ±30.03%          79 μs         208 μs
+Keyword.get/2 + Keyword.replace!/3                           11.37 K       87.94 μs    ±23.55%          84 μs         177 μs
+Keyword.pop/2 + Keyword.put/3                                11.34 K       88.20 μs    ±32.71%          78 μs         209 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing       11.19 K       89.35 μs    ±24.93%          84 μs         184 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing          10.93 K       91.46 μs    ±32.56%          81 μs         219 μs
+
+Comparison:
+Keyword.pop/2 + Keyword.put/3 with Special Casing            12.84 K
+Keyword.get/2 + Keyword.merge/2                              11.58 K - 1.11x slower +8.47 μs
+Keyword.get/2 + Keyword.replace!/3                           11.37 K - 1.13x slower +10.04 μs
+Keyword.pop/2 + Keyword.put/3                                11.34 K - 1.13x slower +10.29 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing       11.19 K - 1.15x slower +11.44 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing          10.93 K - 1.17x slower +13.55 μs

--- a/bench/results/fast_counter/tag_handling/run-2.txt
+++ b/bench/results/fast_counter/tag_handling/run-2.txt
@@ -1,0 +1,153 @@
+Operating System: macOS
+CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+Number of Available Cores: 16
+Available memory: 64 GB
+Elixir 1.7.4
+Erlang 21.3.8.10
+
+Benchmark suite executing with the following configuration:
+warmup: 2 s
+time: 5 s
+memory time: 0 ns
+parallel: 1
+inputs: 1. No Options, 2. No Tags, 3. Empty Tags, 4. One Tag, 5. Five Tags, 6. Ten Tags
+Estimated total run time: 4.20 min
+
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 1. No Options...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 2. No Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 3. Empty Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 4. One Tag...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 5. Five Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 6. Ten Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 1. No Options...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 2. No Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 3. Empty Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 4. One Tag...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 5. Five Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 6. Ten Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 1. No Options...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 2. No Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 3. Empty Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 4. One Tag...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 5. Five Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 6. Ten Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 1. No Options...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 2. No Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 3. Empty Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 4. One Tag...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 5. Five Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 6. Ten Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 1. No Options...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 2. No Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 3. Empty Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 4. One Tag...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 5. Five Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 6. Ten Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 1. No Options...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 2. No Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 3. Empty Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 4. One Tag...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 5. Five Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 6. Ten Tags...
+
+##### With input 1. No Options #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.merge/2                             177.05 K        5.65 μs   ±219.50%        4.98 μs       26.98 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         166.87 K        5.99 μs   ±224.54%        4.98 μs       26.98 μs
+Keyword.get/2 + Keyword.replace!/3                          165.87 K        6.03 μs   ±243.04%        4.98 μs       27.98 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      160.36 K        6.24 μs   ±227.06%        4.98 μs       28.98 μs
+Keyword.pop/2 + Keyword.put/3                               135.37 K        7.39 μs   ±194.26%        6.98 μs       28.98 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing           128.69 K        7.77 μs   ±126.73%        6.98 μs       30.98 μs
+
+Comparison:
+Keyword.get/2 + Keyword.merge/2                             177.05 K
+Keyword.get/2 + Keyword.merge/2 with Special Casing         166.87 K - 1.06x slower +0.34 μs
+Keyword.get/2 + Keyword.replace!/3                          165.87 K - 1.07x slower +0.38 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      160.36 K - 1.10x slower +0.59 μs
+Keyword.pop/2 + Keyword.put/3                               135.37 K - 1.31x slower +1.74 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing           128.69 K - 1.38x slower +2.12 μs
+
+##### With input 2. No Tags #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.merge/2                             174.23 K        5.74 μs   ±221.73%        4.98 μs       26.98 μs
+Keyword.get/2 + Keyword.replace!/3                          166.08 K        6.02 μs   ±266.86%        4.98 μs       28.98 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         139.07 K        7.19 μs   ±144.70%        6.98 μs       28.98 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      135.63 K        7.37 μs   ±124.85%        6.98 μs       29.98 μs
+Keyword.pop/2 + Keyword.put/3                               131.75 K        7.59 μs   ±172.32%        6.98 μs       29.98 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing           128.07 K        7.81 μs   ±120.53%        6.98 μs       30.98 μs
+
+Comparison:
+Keyword.get/2 + Keyword.merge/2                             174.23 K
+Keyword.get/2 + Keyword.replace!/3                          166.08 K - 1.05x slower +0.28 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         139.07 K - 1.25x slower +1.45 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      135.63 K - 1.28x slower +1.63 μs
+Keyword.pop/2 + Keyword.put/3                               131.75 K - 1.32x slower +1.85 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing           128.07 K - 1.36x slower +2.07 μs
+
+##### With input 3. Empty Tags #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.merge/2 with Special Casing         150.27 K        6.65 μs   ±143.67%        5.98 μs       28.98 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      146.51 K        6.83 μs   ±132.87%        5.98 μs       28.98 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            70.97 K       14.09 μs    ±46.01%       12.98 μs       43.98 μs
+Keyword.get/2 + Keyword.replace!/3                           65.28 K       15.32 μs    ±67.04%       12.98 μs       52.98 μs
+Keyword.pop/2 + Keyword.put/3                                60.67 K       16.48 μs    ±39.86%       14.98 μs       50.98 μs
+Keyword.get/2 + Keyword.merge/2                              42.03 K       23.79 μs    ±41.73%       20.98 μs       67.98 μs
+
+Comparison:
+Keyword.get/2 + Keyword.merge/2 with Special Casing         150.27 K
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      146.51 K - 1.03x slower +0.171 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            70.97 K - 2.12x slower +7.44 μs
+Keyword.get/2 + Keyword.replace!/3                           65.28 K - 2.30x slower +8.66 μs
+Keyword.pop/2 + Keyword.put/3                                60.67 K - 2.48x slower +9.83 μs
+Keyword.get/2 + Keyword.merge/2                              42.03 K - 3.58x slower +17.14 μs
+
+##### With input 4. One Tag #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.merge/2 with Special Casing         153.97 K        6.49 μs   ±125.30%        5.98 μs       27.98 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      152.25 K        6.57 μs   ±126.39%        5.98 μs       28.98 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            74.45 K       13.43 μs    ±47.01%       11.98 μs       42.98 μs
+Keyword.get/2 + Keyword.replace!/3                           64.70 K       15.46 μs    ±52.38%       12.98 μs       50.98 μs
+Keyword.pop/2 + Keyword.put/3                                57.05 K       17.53 μs    ±47.19%       15.98 μs       56.98 μs
+Keyword.get/2 + Keyword.merge/2                              41.84 K       23.90 μs    ±44.72%       20.98 μs       68.98 μs
+
+Comparison:
+Keyword.get/2 + Keyword.merge/2 with Special Casing         153.97 K
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      152.25 K - 1.01x slower +0.0733 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            74.45 K - 2.07x slower +6.94 μs
+Keyword.get/2 + Keyword.replace!/3                           64.70 K - 2.38x slower +8.96 μs
+Keyword.pop/2 + Keyword.put/3                                57.05 K - 2.70x slower +11.03 μs
+Keyword.get/2 + Keyword.merge/2                              41.84 K - 3.68x slower +17.41 μs
+
+##### With input 5. Five Tags #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.replace!/3 with Special Casing       30.19 K       33.13 μs    ±36.26%       28.98 μs       91.98 μs
+Keyword.get/2 + Keyword.replace!/3                           28.88 K       34.62 μs    ±41.62%       29.98 μs       99.98 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            27.26 K       36.68 μs    ±33.83%       31.98 μs       94.98 μs
+Keyword.pop/2 + Keyword.put/3                                26.95 K       37.11 μs    ±38.91%       31.98 μs      103.98 μs
+Keyword.get/2 + Keyword.merge/2                              23.02 K       43.45 μs    ±36.66%       37.98 μs      115.98 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing          22.47 K       44.51 μs    ±34.87%       38.98 μs      116.98 μs
+
+Comparison:
+Keyword.get/2 + Keyword.replace!/3 with Special Casing       30.19 K
+Keyword.get/2 + Keyword.replace!/3                           28.88 K - 1.05x slower +1.49 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            27.26 K - 1.11x slower +3.55 μs
+Keyword.pop/2 + Keyword.put/3                                26.95 K - 1.12x slower +3.98 μs
+Keyword.get/2 + Keyword.merge/2                              23.02 K - 1.31x slower +10.32 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing          22.47 K - 1.34x slower +11.39 μs
+
+##### With input 6. Ten Tags #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.replace!/3 with Special Casing       12.81 K       78.07 μs    ±33.22%       68.98 μs      189.98 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            12.74 K       78.48 μs    ±32.45%       69.98 μs      190.98 μs
+Keyword.get/2 + Keyword.replace!/3                           12.41 K       80.60 μs    ±32.59%       69.98 μs      194.98 μs
+Keyword.pop/2 + Keyword.put/3                                11.57 K       86.40 μs    ±28.26%       81.98 μs      189.98 μs
+Keyword.get/2 + Keyword.merge/2                              11.10 K       90.10 μs    ±31.08%       80.98 μs      215.98 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing          10.78 K       92.73 μs    ±27.41%       84.98 μs      207.98 μs
+
+Comparison:
+Keyword.get/2 + Keyword.replace!/3 with Special Casing       12.81 K
+Keyword.pop/2 + Keyword.put/3 with Special Casing            12.74 K - 1.01x slower +0.41 μs
+Keyword.get/2 + Keyword.replace!/3                           12.41 K - 1.03x slower +2.54 μs
+Keyword.pop/2 + Keyword.put/3                                11.57 K - 1.11x slower +8.33 μs
+Keyword.get/2 + Keyword.merge/2                              11.10 K - 1.15x slower +12.04 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing          10.78 K - 1.19x slower +14.66 μs

--- a/bench/results/fast_counter/tag_handling/run-3.txt
+++ b/bench/results/fast_counter/tag_handling/run-3.txt
@@ -1,0 +1,153 @@
+Operating System: macOS
+CPU Information: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+Number of Available Cores: 16
+Available memory: 64 GB
+Elixir 1.7.4
+Erlang 21.3.8.10
+
+Benchmark suite executing with the following configuration:
+warmup: 2 s
+time: 5 s
+memory time: 0 ns
+parallel: 1
+inputs: 1. No Options, 2. No Tags, 3. Empty Tags, 4. One Tag, 5. Five Tags, 6. Ten Tags
+Estimated total run time: 4.20 min
+
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 1. No Options...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 2. No Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 3. Empty Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 4. One Tag...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 5. Five Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with input 6. Ten Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 1. No Options...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 2. No Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 3. Empty Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 4. One Tag...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 5. Five Tags...
+Benchmarking Keyword.get/2 + Keyword.merge/2 with Special Casing with input 6. Ten Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 1. No Options...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 2. No Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 3. Empty Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 4. One Tag...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 5. Five Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with input 6. Ten Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 1. No Options...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 2. No Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 3. Empty Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 4. One Tag...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 5. Five Tags...
+Benchmarking Keyword.get/2 + Keyword.replace!/3 with Special Casing with input 6. Ten Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 1. No Options...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 2. No Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 3. Empty Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 4. One Tag...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 5. Five Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with input 6. Ten Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 1. No Options...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 2. No Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 3. Empty Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 4. One Tag...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 5. Five Tags...
+Benchmarking Keyword.pop/2 + Keyword.put/3 with Special Casing with input 6. Ten Tags...
+
+##### With input 1. No Options #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.merge/2                             166.32 K        6.01 μs   ±260.69%           5 μs          26 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      161.29 K        6.20 μs   ±217.41%           5 μs          28 μs
+Keyword.get/2 + Keyword.replace!/3                          159.78 K        6.26 μs   ±251.24%           6 μs          27 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         158.08 K        6.33 μs   ±122.79%           6 μs          29 μs
+Keyword.pop/2 + Keyword.put/3                               131.11 K        7.63 μs   ±189.69%           7 μs          29 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing           129.63 K        7.71 μs   ±192.99%           7 μs          31 μs
+
+Comparison:
+Keyword.get/2 + Keyword.merge/2                             166.32 K
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      161.29 K - 1.03x slower +0.187 μs
+Keyword.get/2 + Keyword.replace!/3                          159.78 K - 1.04x slower +0.25 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         158.08 K - 1.05x slower +0.31 μs
+Keyword.pop/2 + Keyword.put/3                               131.11 K - 1.27x slower +1.61 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing           129.63 K - 1.28x slower +1.70 μs
+
+##### With input 2. No Tags #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      156.50 K        6.39 μs   ±128.46%           6 μs          28 μs
+Keyword.get/2 + Keyword.merge/2                             156.33 K        6.40 μs   ±130.17%           6 μs          27 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         153.62 K        6.51 μs   ±136.05%           6 μs          28 μs
+Keyword.get/2 + Keyword.replace!/3                          153.45 K        6.52 μs   ±130.77%           6 μs          26 μs
+Keyword.pop/2 + Keyword.put/3                               129.45 K        7.73 μs   ±176.45%           7 μs          30 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing           128.31 K        7.79 μs   ±115.90%           7 μs          31 μs
+
+Comparison:
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      156.50 K
+Keyword.get/2 + Keyword.merge/2                             156.33 K - 1.00x slower +0.00678 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         153.62 K - 1.02x slower +0.120 μs
+Keyword.get/2 + Keyword.replace!/3                          153.45 K - 1.02x slower +0.127 μs
+Keyword.pop/2 + Keyword.put/3                               129.45 K - 1.21x slower +1.34 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing           128.31 K - 1.22x slower +1.40 μs
+
+##### With input 3. Empty Tags #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      152.84 K        6.54 μs   ±118.68%           6 μs          29 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         149.59 K        6.69 μs   ±119.45%           6 μs          29 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            76.52 K       13.07 μs    ±45.99%          12 μs          42 μs
+Keyword.get/2 + Keyword.replace!/3                           62.39 K       16.03 μs    ±54.14%          15 μs          48 μs
+Keyword.pop/2 + Keyword.put/3                                53.79 K       18.59 μs    ±47.89%          16 μs          59 μs
+Keyword.get/2 + Keyword.merge/2                              39.50 K       25.32 μs    ±37.72%          24 μs          65 μs
+
+Comparison:
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      152.84 K
+Keyword.get/2 + Keyword.merge/2 with Special Casing         149.59 K - 1.02x slower +0.142 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            76.52 K - 2.00x slower +6.53 μs
+Keyword.get/2 + Keyword.replace!/3                           62.39 K - 2.45x slower +9.49 μs
+Keyword.pop/2 + Keyword.put/3                                53.79 K - 2.84x slower +12.05 μs
+Keyword.get/2 + Keyword.merge/2                              39.50 K - 3.87x slower +18.77 μs
+
+##### With input 4. One Tag #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      153.09 K        6.53 μs   ±145.34%           6 μs          29 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing         150.47 K        6.65 μs   ±118.33%           6 μs          29 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            75.38 K       13.27 μs    ±46.02%          12 μs          42 μs
+Keyword.get/2 + Keyword.replace!/3                           59.09 K       16.92 μs    ±54.38%          16 μs          44 μs
+Keyword.pop/2 + Keyword.put/3                                50.62 K       19.75 μs    ±44.88%          17 μs          60 μs
+Keyword.get/2 + Keyword.merge/2                              40.60 K       24.63 μs    ±48.74%          21 μs          76 μs
+
+Comparison:
+Keyword.get/2 + Keyword.replace!/3 with Special Casing      153.09 K
+Keyword.get/2 + Keyword.merge/2 with Special Casing         150.47 K - 1.02x slower +0.114 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            75.38 K - 2.03x slower +6.73 μs
+Keyword.get/2 + Keyword.replace!/3                           59.09 K - 2.59x slower +10.39 μs
+Keyword.pop/2 + Keyword.put/3                                50.62 K - 3.02x slower +13.22 μs
+Keyword.get/2 + Keyword.merge/2                              40.60 K - 3.77x slower +18.10 μs
+
+##### With input 5. Five Tags #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.get/2 + Keyword.replace!/3 with Special Casing       29.32 K       34.11 μs    ±36.48%          30 μs          94 μs
+Keyword.get/2 + Keyword.replace!/3                           28.14 K       35.54 μs    ±40.11%          32 μs          96 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            27.47 K       36.41 μs    ±35.24%          32 μs          99 μs
+Keyword.pop/2 + Keyword.put/3                                26.17 K       38.22 μs    ±32.58%          35 μs          99 μs
+Keyword.get/2 + Keyword.merge/2                              21.57 K       46.36 μs    ±30.62%          44 μs         112 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing          21.12 K       47.35 μs    ±28.81%          45 μs         110 μs
+
+Comparison:
+Keyword.get/2 + Keyword.replace!/3 with Special Casing       29.32 K
+Keyword.get/2 + Keyword.replace!/3                           28.14 K - 1.04x slower +1.43 μs
+Keyword.pop/2 + Keyword.put/3 with Special Casing            27.47 K - 1.07x slower +2.30 μs
+Keyword.pop/2 + Keyword.put/3                                26.17 K - 1.12x slower +4.11 μs
+Keyword.get/2 + Keyword.merge/2                              21.57 K - 1.36x slower +12.25 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing          21.12 K - 1.39x slower +13.24 μs
+
+##### With input 6. Ten Tags #####
+Name                                                             ips        average  deviation         median         99th %
+Keyword.pop/2 + Keyword.put/3 with Special Casing            13.01 K       76.88 μs    ±29.92%          69 μs         186 μs
+Keyword.get/2 + Keyword.replace!/3 with Special Casing       12.77 K       78.31 μs    ±32.18%          70 μs         192 μs
+Keyword.get/2 + Keyword.replace!/3                           12.74 K       78.47 μs    ±31.99%          70 μs         190 μs
+Keyword.pop/2 + Keyword.put/3                                11.75 K       85.11 μs    ±34.38%          74 μs         207 μs
+Keyword.get/2 + Keyword.merge/2                              11.09 K       90.14 μs    ±30.51%          82 μs         213 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing          10.36 K       96.50 μs    ±27.80%          92 μs         209 μs
+
+Comparison:
+Keyword.pop/2 + Keyword.put/3 with Special Casing            13.01 K
+Keyword.get/2 + Keyword.replace!/3 with Special Casing       12.77 K - 1.02x slower +1.43 μs
+Keyword.get/2 + Keyword.replace!/3                           12.74 K - 1.02x slower +1.59 μs
+Keyword.pop/2 + Keyword.put/3                                11.75 K - 1.11x slower +8.23 μs
+Keyword.get/2 + Keyword.merge/2                              11.09 K - 1.17x slower +13.26 μs
+Keyword.get/2 + Keyword.merge/2 with Special Casing          10.36 K - 1.26x slower +19.62 μs

--- a/lib/fast_counter.ex
+++ b/lib/fast_counter.ex
@@ -38,11 +38,25 @@ defmodule Instruments.FastCounter do
   @spec increment(iodata) :: :ok
   @spec increment(iodata, integer) :: :ok
   @spec increment(iodata, integer, Statix.options()) :: :ok
-  def increment(name, amount \\ 1, options \\ []) do
+  def increment(name, amount \\ 1, options \\ [])
+
+  def increment(name, amount, []) do
+    table_key = {name, []}
+    :ets.update_counter(current_table(), table_key, amount, {table_key, 0})
+    :ok
+  end
+
+  def increment(name, amount, options) do
     table_key =
       case Keyword.get(options, :tags) do
+        [] ->
+          {name, options}
+
+        [_] ->
+          {name, options}
+
         tags when is_list(tags) ->
-          {name, Keyword.merge(options, tags: Enum.sort(tags))}
+          {name, Keyword.replace!(options, :tags, Enum.sort(tags))}
 
         _ ->
           {name, options}

--- a/lib/fast_counter.ex
+++ b/lib/fast_counter.ex
@@ -13,6 +13,7 @@ defmodule Instruments.FastCounter do
                                   :fast_counter_report_interval,
                                   10_000
                                 )
+  @compile {:inline, get_table_key: 2}
 
   use GenServer
 
@@ -38,30 +39,8 @@ defmodule Instruments.FastCounter do
   @spec increment(iodata) :: :ok
   @spec increment(iodata, integer) :: :ok
   @spec increment(iodata, integer, Statix.options()) :: :ok
-  def increment(name, amount \\ 1, options \\ [])
-
-  def increment(name, amount, []) do
-    table_key = {name, []}
-    :ets.update_counter(current_table(), table_key, amount, {table_key, 0})
-    :ok
-  end
-
-  def increment(name, amount, options) do
-    table_key =
-      case Keyword.get(options, :tags) do
-        [] ->
-          {name, options}
-
-        [_] ->
-          {name, options}
-
-        tags when is_list(tags) ->
-          {name, Keyword.replace!(options, :tags, Enum.sort(tags))}
-
-        _ ->
-          {name, options}
-      end
-
+  def increment(name, amount \\ 1, options \\ []) do
+    table_key = get_table_key(name, options)
     :ets.update_counter(current_table(), table_key, amount, {table_key, 0})
     :ok
   end
@@ -102,6 +81,26 @@ defmodule Instruments.FastCounter do
   end
 
   ## Private
+
+  defp get_table_key(name, []) do
+    {name, []}
+  end
+
+  defp get_table_key(name, options) do
+    case Keyword.get(options, :tags) do
+      [] ->
+        {name, options}
+
+      [_] ->
+        {name, options}
+
+      tags when is_list(tags) ->
+        {name, Keyword.replace!(options, :tags, Enum.sort(tags))}
+
+      _ ->
+        {name, options}
+    end
+  end
 
   defp report_stat({_key, 0}, _),
     do: :ok

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Instruments.Mixfile do
       app: :instruments,
       name: "Instruments",
       version: @version,
-      elixir: "~> 1.3",
+      elixir: "~> 1.5",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       elixirc_paths: compile_paths(Mix.env()),

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Instruments.Mixfile do
   use Mix.Project
 
-  @version "1.1.3"
+  @version "2.0.0"
   @github_url "https://github.com/discord/instruments"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule Instruments.Mixfile do
 
   defp deps do
     [
+      {:benchee, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
       {:recon, "~> 2.3.1"},
       {:statix, "~> 1.2.1"}

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,11 @@
 %{
-  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.2", "6f4081ccd9ed081b6dc0bd5af97a41e87f5554de469e7d76025fba535180565f", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
-  "recon": {:hex, :recon, "2.3.2", "4444c879be323b1b133eec5241cb84bd3821ea194c740d75617e106be4744318", [:rebar3], [], "hexpm"},
-  "statix": {:hex, :statix, "1.2.1", "4f23c8cc2477ea0de89fed5e34f08c54b0d28b838f7b8f26613155f2221bb31e", [:mix], [], "hexpm"},
+  "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm", "000aaeff08919e95e7aea13e4af7b2b9734577b3e6a7c50ee31ee88cab6ec4fb"},
+  "ex_doc": {:hex, :ex_doc, "0.19.2", "6f4081ccd9ed081b6dc0bd5af97a41e87f5554de469e7d76025fba535180565f", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "4eae888633d2937e0a8839ae6002536d459c22976743c9dc98dd05941a06c016"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "5fbc8e549aa9afeea2847c0769e3970537ed302f93a23ac612602e805d9d1e7f"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "adf0218695e22caeda2820eaba703fa46c91820d53813a2223413da3ef4ba515"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
+  "recon": {:hex, :recon, "2.3.2", "4444c879be323b1b133eec5241cb84bd3821ea194c740d75617e106be4744318", [:rebar3], [], "hexpm", "a6fcfbdabe1aef9119b871304846b1ce282d9a4124bcddafc7616c1a256c7596"},
+  "statix": {:hex, :statix, "1.2.1", "4f23c8cc2477ea0de89fed5e34f08c54b0d28b838f7b8f26613155f2221bb31e", [:mix], [], "hexpm", "7f988988fddcce19ae376bb8e47aa5ea5dabf8d4ba78d34d1ae61eb537daf72e"},
 }


### PR DESCRIPTION
⚠️ This PR relies on `Keyword.replace!/3` which was added in Elixir 1.5.0, the mix.exs has been updated to indicate this but this would effectively be a major version breaking change since the current library supports down to Elixir 1.3 ⚠️ 

FastCounter, as the name implies, provides a fast counter.  Since the FastCounter is used in very hot paths, optimizing its performance can yield system wide improvements for any systems using Instruments.

This PR is mostly supporting data and analysis of the best strategy for `Instruments.FastCounter.increment/3`

The previous strategy attempts to generate stable ETS keys by normalizing the incoming options, in practice the use of `Keyword.merge/2` means that the keys end up semi-stable since [the documentation](https://hexdocs.pm/elixir/Keyword.html#merge/2) provide the following caveat:

> There are no guarantees about the order of keys in the returned keyword.

So while the previous strategy would ensure the order of the `:tags` key, it does not guarantee the order of the options after the merge and therefore does not guarantee the stability of the key.

This actually doesn't really seem to matter because the duplicate keys are all processed and the stats will be aggregated by the metrics processor.

I'm inclined to actually just remove the sorting of the tags altogether, but this is a slightly less drastic change that continues the current strategy but adds a few special cases to improve performance.

- A special `increment/3` arm was added for when no options are passed.  This arm can skip all table_key calculation for the common case of simple non-tagged metric increments.
- Two special cases were added to the case statement for when options are present, one for when tags is an empty list, and one for when tags is a list of exactly 1 element.  In both cases the sorted version of these tags values is identical to the provided value so the `Enum.sort/1` and `Keyword.replace!/3` calls can be completely obviated.
- Finally `Keyword.merge/2` was replaced with `Keyword.replace!/3` which proved to have better performance characteristics under benchmarking.  Merge is not really necessary here as only a single key in the Keyword needs to be updated and that key is known and known to exist at the point where the write is executed.