### PR TITLE
Allow probes with the same name and at least one unique tag

### DIFF
--- a/lib/probe/definitions.ex
+++ b/lib/probe/definitions.ex
@@ -109,7 +109,7 @@ defmodule Instruments.Probe.Definitions do
   defp unique_names(probe_names, options) do
     case Keyword.get(options, :tags) do
       tags when is_list(tags) ->
-        tag_string = inspect(Enum.sort(tags))
+        tag_string = Enum.join(Enum.sort(tags), ",")
         for probe_name <- probe_names do
           "#{probe_name}.tags:#{tag_string}"
         end

--- a/lib/probe/definitions.ex
+++ b/lib/probe/definitions.ex
@@ -109,8 +109,9 @@ defmodule Instruments.Probe.Definitions do
   defp unique_names(probe_names, options) do
     case Keyword.get(options, :tags) do
       tags when is_list(tags) ->
-        for probe_name <- probe_names, tag <- tags do
-          "#{probe_name}.tag:#{tag}"
+        tag_string = inspect(Enum.sort(tags))
+        for probe_name <- probe_names do
+          "#{probe_name}.tags:#{tag_string}"
         end
 
       nil ->

--- a/test/probe/probe_test.exs
+++ b/test/probe/probe_test.exs
@@ -234,10 +234,15 @@ defmodule Instruments.ProbeTest do
       end
     end
 
-    test "it should not let you define two probes that have the same name any shared tags" do
+    test "it should let you define two probes that have the same name and at least one different tag" do
       Probe.define!("probe.with.tags", :gauge, function: fn -> 9 end, tags: [:tagE, :tagF])
+      Probe.define!("probe.with.tags", :gauge, function: fn -> 9 end, tags: [:tagG, :tagE])
+    end
+
+    test "it should not let you define two probes that have the same tags in a different order" do
+      Probe.define!("probe.with.tags", :gauge, function: fn -> 9 end, tags: [:tagG, :tagH])
       assert_raise ProbeNameTakenError, fn ->
-        Probe.define!("probe.with.tags", :gauge, function: fn -> 9 end, tags: [:tagG, :tagE])
+        Probe.define!("probe.with.tags", :gauge, function: fn -> 9 end, tags: [:tagH, :tagG])
       end
     end
   end


### PR DESCRIPTION
This changes the behavior from #14 to allow shared tags, as long as at least one of the tags is different.

For an example, I need this for a probe that is checking connections, and each connection has a category "default" or "fancy" and a number 0-16.
I'd like to have tags on the probe like:
```elixir
tags: ["category:#{category}",  "number:#{number}"]
```
The combination will be unique, but not the individual tags.