### PR TITLE
Version 2.1.2: Upgrade to Recon 2.5.1 from 2.3 (otp23 compat)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,24 +8,26 @@ on:
 
 jobs:
   build:
-
     name: Build and test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
+      # This depends on listening on a UDP socket on a fixed port so only 1 at a time.
+      max-parallel: 1
       matrix:
+        elixir-version: ['1.6.6', '1.7.4', '1.10.4']
+        otp-version: ['20.3', '21.3']
+        exclude:
+          - elixir-version: 1.10.4
+            otp-version: 20.3
         include:
-          - elixir-version: 1.6.6
-            otp-version: 20.3
-          - elixir-version: 1.6.6
-            otp-version: 21.3
-          - elixir-version: 1.7.4
-            otp-version: 20.3
-          - elixir-version: 1.7.4
+          - elixir-version: 1.11.4
+            otp-version: 23.3
+          - elixir-version: 1.11.4
             otp-version: 21.3
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir-version }}
         otp-version: ${{ matrix.otp-version }}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Instruments.Mixfile do
   use Mix.Project
 
-  @version "2.1.1"
+  @version "2.1.2"
   @github_url "https://github.com/discord/instruments"
 
   def project do
@@ -50,7 +50,7 @@ defmodule Instruments.Mixfile do
     [
       {:benchee, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
-      {:recon, "~> 2.3.1"},
+      {:recon, "~> 2.5"},
       {:statix, "~> 1.2.1"},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,6 @@
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "5fbc8e549aa9afeea2847c0769e3970537ed302f93a23ac612602e805d9d1e7f"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "adf0218695e22caeda2820eaba703fa46c91820d53813a2223413da3ef4ba515"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
-  "recon": {:hex, :recon, "2.3.2", "4444c879be323b1b133eec5241cb84bd3821ea194c740d75617e106be4744318", [:rebar3], [], "hexpm", "a6fcfbdabe1aef9119b871304846b1ce282d9a4124bcddafc7616c1a256c7596"},
+  "recon": {:hex, :recon, "2.5.1", "430ffa60685ac1efdfb1fe4c97b8767c92d0d92e6e7c3e8621559ba77598678a", [:mix, :rebar3], [], "hexpm", "5721c6b6d50122d8f68cccac712caa1231f97894bab779eff5ff0f886cb44648"},
   "statix": {:hex, :statix, "1.2.1", "4f23c8cc2477ea0de89fed5e34f08c54b0d28b838f7b8f26613155f2221bb31e", [:mix], [], "hexpm", "7f988988fddcce19ae376bb8e47aa5ea5dabf8d4ba78d34d1ae61eb537daf72e"},
 }


### PR DESCRIPTION
In order for instruments to be compatible with OTP 23, we need to use a more modern Recon. 2.5.1 fits the bill.