### PR TITLE
Pin instruments CI to ubuntu 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Running on Ubuntu 20 is currently failing before even getting to the tests due to the old versions of elixir/OTP depending on an old version of libcrypto which seems to be absent.