### PR TITLE
Update to current master of recon

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Instruments.Mixfile do
   use Mix.Project
 
-  @version "2.1.2"
+  @version "2.1.3"
   @github_url "https://github.com/discord/instruments"
 
   def project do
@@ -50,7 +50,7 @@ defmodule Instruments.Mixfile do
     [
       {:benchee, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
-      {:recon, "~> 2.5"},
+      {:recon, github: "ferd/recon", ref: "508148d633ff0de7262d953547a984edec0722bb"},
       {:statix, "~> 1.2.1"},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,6 @@
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "5fbc8e549aa9afeea2847c0769e3970537ed302f93a23ac612602e805d9d1e7f"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "adf0218695e22caeda2820eaba703fa46c91820d53813a2223413da3ef4ba515"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
-  "recon": {:hex, :recon, "2.5.1", "430ffa60685ac1efdfb1fe4c97b8767c92d0d92e6e7c3e8621559ba77598678a", [:mix, :rebar3], [], "hexpm", "5721c6b6d50122d8f68cccac712caa1231f97894bab779eff5ff0f886cb44648"},
+  "recon": {:git, "https://github.com/ferd/recon.git", "508148d633ff0de7262d953547a984edec0722bb", [ref: "508148d633ff0de7262d953547a984edec0722bb"]},
   "statix": {:hex, :statix, "1.2.1", "4f23c8cc2477ea0de89fed5e34f08c54b0d28b838f7b8f26613155f2221bb31e", [:mix], [], "hexpm", "7f988988fddcce19ae376bb8e47aa5ea5dabf8d4ba78d34d1ae61eb537daf72e"},
 }

--- a/test/support/fake_statsd.ex
+++ b/test/support/fake_statsd.ex
@@ -12,7 +12,7 @@ defmodule FakeStatsd do
   end
 
   def init([test_process]) do
-    {:ok, sock} = :gen_udp.open(Instruments.statsd_port(), [:binary, active: true])
+    {:ok, sock} = :gen_udp.open(Instruments.statsd_port(), [:binary, active: true, reuseaddr: true])
     {:ok, {test_process, sock}}
   end
 


### PR DESCRIPTION
There is a bug in :recon_alloc.memory(:used) in OTP 23 that was fixed last November but has not been packed into a release (https://github.com/ferd/recon/pull/83).