### PR TITLE
Make supervisors use Elixir 1.5-based specs

### DIFF
--- a/lib/fast_counter.ex
+++ b/lib/fast_counter.ex
@@ -17,7 +17,7 @@ defmodule Instruments.FastCounter do
 
   use GenServer
 
-  def start_link() do
+  def start_link(_ \\ []) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 

--- a/lib/instruments/application.ex
+++ b/lib/instruments/application.ex
@@ -9,18 +9,15 @@ defmodule Instruments.Application do
   }
 
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
     reporter = Application.get_env(:instruments, :reporter_module, Instruments.Statix)
     reporter.connect()
 
     children = [
-      worker(FastCounter, []),
-      worker(Probe.Definitions, []),
-      worker(Probe.Supervisor, [])
+      FastCounter,
+      Probe.Definitions,
+      Probe.Supervisor,
     ]
 
-    opts = [strategy: :one_for_one, name: Instruments.Supervisor]
-    Supervisor.start_link(children, opts)
+    Supervisor.start_link(children, strategy: :one_for_one, name: Instruments.Supervisor)
   end
 end

--- a/lib/probe/definitions.ex
+++ b/lib/probe/definitions.ex
@@ -11,7 +11,7 @@ defmodule Instruments.Probe.Definitions do
   @probe_prefix Application.get_env(:instruments, :probe_prefix)
   @table_name :probe_definitions
 
-  def start_link(), do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(_ \\ []), do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
 
   def init([]) do
     table_name = @table_name

--- a/lib/probe/runner.ex
+++ b/lib/probe/runner.ex
@@ -67,7 +67,12 @@ defmodule Instruments.Probe.Runner do
 
   @spec start_link(String.t(), Probe.probe_type(), Probe.probe_options(), module) :: {:ok, pid}
   def start_link(name, type, options, probe_module) do
-    GenServer.start_link(__MODULE__, {name, type, options, probe_module})
+    start_link({name, type, options, probe_module})
+  end
+
+  @spec start_link({String.t(), Probe.probe_type(), Probe.probe_options(), module}) :: {:ok, pid}
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args)
   end
 
   def flush(probe_pid) do

--- a/lib/probe/supervisor.ex
+++ b/lib/probe/supervisor.ex
@@ -1,20 +1,16 @@
 defmodule Instruments.Probe.Supervisor do
   @moduledoc false
-  use Supervisor
+  use DynamicSupervisor
 
-  def start_link do
-    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(_ \\ []) do
+    DynamicSupervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   def init([]) do
-    children = [
-      worker(Instruments.Probe.Runner, [])
-    ]
-
-    supervise(children, strategy: :simple_one_for_one)
+    DynamicSupervisor.init(strategy: :one_for_one)
   end
 
   def start_probe(name, type, options, probe_module) do
-    Supervisor.start_child(__MODULE__, [name, type, options, probe_module])
+    DynamicSupervisor.start_child(__MODULE__, {Instruments.Probe.Runner, {name, type, options, probe_module}})
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Instruments.Mixfile do
   use Mix.Project
 
-  @version "2.1.3"
+  @version "2.1.4"
   @github_url "https://github.com/discord/instruments"
 
   def project do


### PR DESCRIPTION
This should be backward compatible as far as APIs go (assuming people didn't add children to Instruments.Probe.Supervisor without using the helper function.