### PR TITLE
Moduledoc improvement 

### DIFF
--- a/lib/probes/schedulers.ex
+++ b/lib/probes/schedulers.ex
@@ -17,7 +17,7 @@ defmodule Instruments.Probes.Schedulers do
   initialization:
 
       alias Instruments
-      Probe.define!("erlang.scheduler_utilization", :gauge, Probes.Schedulers, keys: ~w(weighted total))
+      Probe.define!("erlang.scheduler_utilization", :gauge, module: Probes.Schedules, keys: ~w(weighted total))~
 
   The probe will now report two metrics, `erlang.scheduler_utilization.total` and `erlang.scheduler_utilization.total`.
   """

--- a/lib/probes/schedulers.ex
+++ b/lib/probes/schedulers.ex
@@ -17,7 +17,7 @@ defmodule Instruments.Probes.Schedulers do
   initialization:
 
       alias Instruments
-      Probe.define!("erlang.scheduler_utilization", :gauge, module: Probes.Schedules, keys: ~w(weighted total))~
+      Probe.define!("erlang.scheduler_utilization", :gauge, module: Probes.Schedulers, keys: ~w(weighted total))
 
   The probe will now report two metrics, `erlang.scheduler_utilization.total` and `erlang.scheduler_utilization.total`.
   """


### PR DESCRIPTION
I was getting the following error: 

`function Instruments.Probe.define!/4 is undefined or private` with the code sample `Probe.define!("erlang.scheduler_utilization", :gauge, Probes.Schedulers, keys: ~w(weighted total))` 

Passing a keyword list fixed it 