### PR TITLE
The measure function needs to time the passed-in function

### DIFF
--- a/lib/stats_reporter/logger.ex
+++ b/lib/stats_reporter/logger.ex
@@ -36,7 +36,7 @@ defmodule Instruments.StatsReporter.Logger do
 
   @doc false
   def measure(key, _options \\ [], fun) do
-    {time_in_us, result} = fun.()
+    {time_in_us, result} = :timer.tc(fun)
     Logger.info("#{key} took #{time_in_us / 1000}ms")
     result
   end


### PR DESCRIPTION
In order to match Statix's API, the measure function needs to call
`:timer.tc` and actually measure the timing of the passed in
function. The current implementation didn't do that and would fail the
pattern match.