### PR TITLE
Provide better output on broken probes

### DIFF
--- a/lib/probe/runner.ex
+++ b/lib/probe/runner.ex
@@ -142,6 +142,9 @@ defmodule Instruments.Probe.Runner do
 
       nil ->
         Logger.info("Not Sending #{state.name} due to nil return")
+
+      invalid ->
+        Logger.warning("Probe #{state.name} has returned an invalid value: #{inspect(invalid)}")
     end
   end
 

--- a/lib/probe/runner.ex
+++ b/lib/probe/runner.ex
@@ -144,7 +144,7 @@ defmodule Instruments.Probe.Runner do
         Logger.info("Not Sending #{state.name} due to nil return")
 
       invalid ->
-        Logger.warning("Probe #{state.name} has returned an invalid value: #{inspect(invalid)}")
+        Logger.warn("Probe #{state.name} has returned an invalid value: #{inspect(invalid)}")
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,16 +5,16 @@ defmodule MetricsAssertions do
   use ExUnit.Case
 
   def assert_metric_reported(metric_type, metric_name) do
-    assert_receive {:metric_reported, {^metric_type, ^metric_name, _, _}}
+    assert_receive {:metric_reported, {^metric_type, ^metric_name, _, _}}, 5000
   end
 
   def assert_metric_reported(metric_type, metric_name, metric_value)
       when is_number(metric_value) do
-    assert_receive {:metric_reported, {^metric_type, ^metric_name, ^metric_value, _}}
+    assert_receive {:metric_reported, {^metric_type, ^metric_name, ^metric_value, _}}, 5000
   end
 
   def assert_metric_reported(metric_type, metric_name, expected_metric_value) do
-    assert_receive {:metric_reported, {^metric_type, ^metric_name, actual_value, _}}
+    assert_receive {:metric_reported, {^metric_type, ^metric_name, actual_value, _}}, 5000
 
     cond do
       range?(expected_metric_value) ->
@@ -27,14 +27,14 @@ defmodule MetricsAssertions do
 
   def assert_metric_reported(metric_type, metric_name, metric_value, options)
       when is_number(metric_value) do
-    assert_receive {:metric_reported, {^metric_type, ^metric_name, ^metric_value, actual_options}}
+    assert_receive {:metric_reported, {^metric_type, ^metric_name, ^metric_value, actual_options}}, 5000
 
     do_assert_options(metric_type, options, actual_options)
   end
 
   def assert_metric_reported(metric_type, metric_name, expected_metric_value, options) do
     assert_receive {:metric_reported,
-                    {^metric_type, ^metric_name, actual_metric_value, actual_options}}
+                    {^metric_type, ^metric_name, actual_metric_value, actual_options}}, 5000
 
     do_assert_options(metric_type, options, actual_options)
 


### PR DESCRIPTION
Right now the probe will just crash and exit if the probe module returns
an invalid value.  With many probes this can make it difficult to find
and correct misbehaving probes.

Instead of crashing, log a warning with the probe name and the invalid
value so the probe can be corrected