### PR TITLE
Add a randomized jitter to FastCounter reporting.

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -5,6 +5,7 @@ use Mix.Config
 config :instruments,
   statsd_port: 15310,
   fast_counter_report_interval: 10,
+  fast_counter_report_jitter_range: 0..0,
   reporter_module: Instruments.Statix
 
 config :logger, compile_time_purge_level: :error, level: :error#, backends: []

--- a/pages/Configuration.md
+++ b/pages/Configuration.md
@@ -23,8 +23,10 @@ There are a couple of `Instruments` specific application variables:
 
 * `reporter_module`: The `Instruments.StatsReporter` that emits statistics for the application. Defaults
                      to `Instruments.Statix`.
-* `fast_counter_report_interval`: How often counters should send data to the `reporter_module`. Defaults
-                                  to 10 seconds.
+* `fast_counter_report_interval`: How often counters should send data to the `reporter_module`, in milliseconds. 
+                                  Defaults to 10 seconds.
+* `fast_counter_report_jitter_range`: How much random jitter should be applied to the reporting interval, in milliseconds.
+                                      Defaults to half a second before and after the reporting interval.
 * `probe_prefix`: A global prefix to apply to all probes.
 * `statsd_port`: The port that the statsd server listens on. Should be the same as the port in the statix 
                  configuration above.
@@ -34,5 +36,6 @@ For example:
      config :instruments, 
        reporter_module: Instruments.StatsReporter.Logger,
        fast_counter_report_interval: 30_000,
+       fast_counter_report_jitter_range: -700..700,
        probe_prefix: "probes",
        statsd_port: 15339


### PR DESCRIPTION
Various situations can cause many scheduled reports from different counters to all send at once.
This randomized jitter will spread out report intervals from different counters so that they are never correlated together.