### PR TITLE
Fix CI by using more recent Elixir/OTP versions, upgrade cache action and base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,17 @@ jobs:
       # This depends on listening on a UDP socket on a fixed port so only 1 at a time.
       max-parallel: 1
       matrix:
-        elixir-version: ['1.6.6', '1.7.4', '1.10.4']
-        otp-version: ['20.3', '21.3']
-        exclude:
-          - elixir-version: 1.10.4
-            otp-version: 20.3
         include:
-          - elixir-version: 1.11.4
-            otp-version: 23.3
-          - elixir-version: 1.11.4
-            otp-version: 21.3
+          - elixir-version: 1.12.3
+            otp-version: 24.3
+          - elixir-version: 1.15.5
+            otp-version: 25.3
+          - elixir-version: 1.16.2
+            otp-version: 25.3
+          - elixir-version: 1.17.3
+            otp-version: 25.3
+          - elixir-version: 1.18.3
+            otp-version: 25.3
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       # This depends on listening on a UDP socket on a fixed port so only 1 at a time.
       max-parallel: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         elixir-version: ${{ matrix.elixir-version }}
         otp-version: ${{ matrix.otp-version }}
     - name: Restore dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ runner.os }}-${{ matrix.elixir-version }}-${{ matrix.otp-version}}-mix-${{ hashFiles('**/mix.lock') }}


### PR DESCRIPTION
It seems that `hex.pm` has removed a lot of the OTP versions in this test matrix ([list here](https://builds.hex.pm/builds/otp/amd64/ubuntu-24.04/builds.txt)), causing our builds to fail.

Additionally, `actions/cache@v2` has been hard-deprecated, so we must upgrade to something more recent in order for these builds to pass.

Lastly, Github won't even run our action due to 20.04 being EOL.