### PR TITLE
Clear the rates table on each report, even if there is no threshold set

### DIFF
--- a/lib/rate_tracker.ex
+++ b/lib/rate_tracker.ex
@@ -107,6 +107,10 @@ defmodule Instruments.RateTracker do
       {_key, 0} -> false
       {_key, _rate} -> true
     end)
+    |> Enum.map(fn {key, count} ->
+      report_interval_seconds = @report_interval_ms / 1000
+      {key, count / report_interval_seconds}
+    end)
     |> Enum.to_list()
   end
 

--- a/lib/rate_tracker.ex
+++ b/lib/rate_tracker.ex
@@ -125,8 +125,9 @@ defmodule Instruments.RateTracker do
 
     # Extraordinarily unlikely to be zero, but if it is for some reason, we'll just skip this
     # and let the next report get it
-    if threshold != nil and time_since_report > 0 do
-      do_report(state, time_since_report, threshold)
+    if time_since_report > 0 do
+      counts = dump_and_clear_counts(state)
+      do_report(state, counts, time_since_report, threshold)
     end
 
     schedule_report()
@@ -173,14 +174,24 @@ defmodule Instruments.RateTracker do
     table_name(:erlang.system_info(:scheduler_id))
   end
 
-  defp aggregate_stats(table_data) do
-    Enum.reduce(table_data, %{}, fn {key, val}, acc ->
-      Map.update(acc, key, val, &(&1 + val))
+  defp do_report(%__MODULE__{} = _state, _aggregated_counts, _time_since_report, nil) do
+    nil
+  end
+
+  defp do_report(%__MODULE__{} = state, aggregated_counts, time_since_report, threshold) do
+    Enum.each(aggregated_counts, fn {key, num_tracked} ->
+      # Sampling correction  is technically approximate (we don't know if Statix or another underlying lib will report this differently)
+      tracked_per_second = num_tracked / time_since_report * sample_rate_for_key(key)
+
+      if tracked_per_second > threshold do
+        Enum.each(state.callbacks, fn callback -> callback.(key, tracked_per_second) end)
+      end
     end)
   end
 
-  defp do_report(%__MODULE__{} = state, time_since_report, threshold) do
-    dump_and_clear_data = fn scheduler_id ->
+  defp dump_and_clear_counts(%__MODULE__{} = state) do
+    1..state.table_count
+    |> Enum.flat_map(fn scheduler_id ->
       table_name = table_name(scheduler_id)
       table_data = :ets.tab2list(table_name)
 
@@ -189,18 +200,13 @@ defmodule Instruments.RateTracker do
       end)
 
       table_data
-    end
-
-    1..state.table_count
-    |> Enum.flat_map(dump_and_clear_data)
+    end)
     |> aggregate_stats()
-    |> Enum.each(fn {key, num_tracked} ->
-      # Sampling correction  is technically approximate (we don't know if Statix or another underlying lib will report this differently)
-      tracked_per_second = num_tracked / time_since_report * sample_rate_for_key(key)
+  end
 
-      if tracked_per_second > threshold do
-        Enum.each(state.callbacks, fn callback -> callback.(key, tracked_per_second) end)
-      end
+  defp aggregate_stats(table_data) do
+    Enum.reduce(table_data, %{}, fn {key, val}, acc ->
+      Map.update(acc, key, val, &(&1 + val))
     end)
   end
 


### PR DESCRIPTION
Right now, we don't clear the rates table unless we have a reporting threshold, which makes it hard to ascertain how many calls per second there are.

Also, as a drive-by, changes the return value of `dump_rates` to actually return ... a rate, rather than the count in ETS